### PR TITLE
Fix - ARM API Url hardcoded to northeurope

### DIFF
--- a/pwsh/AzADSPIDataCollectionIngest.ps1
+++ b/pwsh/AzADSPIDataCollectionIngest.ps1
@@ -50,7 +50,7 @@ else {
 
     $dataCollectionEndpointId = $DCR.properties.dataCollectionEndpointId
     $currentTask = "Get Data Collection Endpoint $($dataCollectionEndpointId)"
-    $uriDCE = "$($azAPICallConf['azAPIEndpointUrls'].ARMnortheurope)$($dataCollectionEndpointId)?api-version=2022-06-01"
+    $uriDCE = "$($azAPICallConf['azAPIEndpointUrls'].ARM)$($dataCollectionEndpointId)?api-version=2022-06-01"
     $dceResourceJson = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uriDCE -method 'Get' -listenOn Content -currentTask $currentTask
     $dceIngestEndpointUrl = $dceResourceJson.properties.logsIngestion.endpoint
 


### PR DESCRIPTION
For some reason, we are using the north europe specific ARM API url for this line.